### PR TITLE
관광특구 대시보드: POI/관광지/문화행사 카드 연동 및 모달 기능 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/stars/dashboard/AccidentAlertCard.tsx
+++ b/src/components/stars/dashboard/AccidentAlertCard.tsx
@@ -27,7 +27,7 @@ export default function AccidentAlertCard({
 }: AccidentAlertCardProps) {
     return (
         <motion.div
-            className="col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-4 bg-blue-500 rounded-3xl shadow-sm p-5 my-2"
+            className="col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-4 bg-blue-500 rounded-3xl shadow-lg p-5 my-2"
             whileHover={{ y: -6 }}
             animate={
                 style
@@ -67,7 +67,7 @@ export default function AccidentAlertCard({
                     {accidents.map((acc, idx) => (
                         <div
                             key={idx}
-                            className="bg-blue-100 rounded-2xl shadow-lg p-3 text-sm"
+                            className="bg-blue-100 rounded-2xl shadow-sm p-3 text-sm"
                         >
                             <div className="flex items-center gap-2 mb-1">
                                 <span className="text-xl">

--- a/src/components/stars/dashboard/AccidentAlertCard.tsx
+++ b/src/components/stars/dashboard/AccidentAlertCard.tsx
@@ -27,7 +27,7 @@ export default function AccidentAlertCard({
 }: AccidentAlertCardProps) {
     return (
         <motion.div
-            className="col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-4 bg-blue-500 rounded-3xl shadow-lg p-5 my-2"
+            className="col-span-12 sm:col-span-6 md:col-span-4 lg:col-span-4 bg-blue-500 rounded-3xl shadow-sm p-5 my-2"
             whileHover={{ y: -6 }}
             animate={
                 style
@@ -46,34 +46,16 @@ export default function AccidentAlertCard({
                     {/* SVG 아이콘 */}
                     <svg
                         xmlns="http://www.w3.org/2000/svg"
-                        x="0px"
-                        y="0px"
                         width="60"
                         height="60"
                         viewBox="0,0,255.99609,255.99609"
                     >
-                        <g
-                            fill="#ffffff"
-                            fillRule="nonzero"
-                            stroke="none"
-                            strokeWidth="1"
-                            strokeLinecap="butt"
-                            strokeLinejoin="miter"
-                            strokeMiterlimit="10"
-                            strokeDasharray=""
-                            strokeDashoffset="0"
-                            fontFamily="none"
-                            fontWeight="none"
-                            fontSize="none"
-                            textAnchor="none"
-                        >
+                        <g fill="#ffffff">
                             <g transform="scale(5.12,5.12)">
                                 <path d="M25,2c-12.683,0 -23,10.317 -23,23c0,12.683 10.317,23 23,23c12.683,0 23,-10.317 23,-23c0,-4.56 -1.33972,-8.81067 -3.63672,-12.38867l-1.36914,1.61719c1.895,3.154 3.00586,6.83148 3.00586,10.77148c0,11.579 -9.421,21 -21,21c-11.579,0 -21,-9.421 -21,-21c0,-11.579 9.421,-21 21,-21c5.443,0 10.39391,2.09977 14.12891,5.50977l1.30859,-1.54492c-4.085,-3.705 -9.5025,-5.96484 -15.4375,-5.96484zM43.23633,7.75391l-19.32227,22.80078l-8.13281,-7.58594l-1.36328,1.46289l9.66602,9.01563l20.67969,-24.40039z"></path>
                             </g>
                         </g>
                     </svg>
-
-                    {/* 안내 텍스트 */}
                     <p className="text-sm font-medium mt-2">
                         현재 이 관광특구에는
                         <br />
@@ -81,14 +63,13 @@ export default function AccidentAlertCard({
                     </p>
                 </div>
             ) : (
-                <div className="grid grid-cols-1 gap-3">
+                <div className="grid grid-cols-1 gap-3 max-h-[300px] overflow-y-auto rounded-2xl scrollbar-none">
                     {accidents.map((acc, idx) => (
                         <div
                             key={idx}
                             className="bg-blue-100 rounded-2xl shadow-lg p-3 text-sm"
                         >
                             <div className="flex items-center gap-2 mb-1">
-                                {/* 아이콘과 유형 뱃지 */}
                                 <span className="text-xl">
                                     {getAccidentIcon(acc.acdnt_type)}
                                 </span>

--- a/src/components/stars/dashboard/AttractionCard.tsx
+++ b/src/components/stars/dashboard/AttractionCard.tsx
@@ -1,10 +1,14 @@
 import { motion } from "framer-motion";
+import { usePlace } from "../../../context/PlaceContext";
+import { SearchResult } from "../../../api/searchApi";
 
 interface Attraction {
     name: string;
     address: string;
     phone?: string;
     homepage_url?: string;
+    lat: number;
+    lon: number;
 }
 
 interface AttractionTableCardProps {
@@ -18,6 +22,8 @@ export default function AttractionTableCard({
     style,
     cardRef,
 }: AttractionTableCardProps) {
+    const { setHighlightPOI, selectedAreaId } = usePlace();
+
     return (
         <motion.div
             className="col-span-12 md:col-span-6 bg-white rounded-3xl shadow-lg p-4 my-2"
@@ -34,10 +40,30 @@ export default function AttractionTableCard({
                 {attractions.map((a, idx) => (
                     <li
                         key={idx}
-                        className="p-3 rounded-xl bg-gray-50 hover:bg-orange-50 shadow-sm transition"
+                        onClick={() => {
+                            const data: SearchResult = {
+                                place_id: idx + 1,
+                                name: a.name,
+                                address: a.address,
+                                phone: a.phone,
+                                lon: a.lon,
+                                lat: a.lat,
+                                type: "attraction",
+                                area_id: selectedAreaId ?? undefined,
+                            };
+                            setHighlightPOI(data);
+                            (
+                                window as unknown as {
+                                    fullpage_api?: {
+                                        moveTo: (n: number) => void;
+                                    };
+                                }
+                            ).fullpage_api?.moveTo(1);
+                        }}
+                        className="p-3 rounded-xl bg-gray-50 hover:bg-orange-50 shadow-sm transition cursor-pointer"
                     >
                         <p className="text-sm font-semibold text-gray-800">
-                            {a.name}
+                            📍 {a.name}
                         </p>
                         <p className="text-xs text-gray-500">{a.address}</p>
                         {a.phone && (
@@ -51,6 +77,7 @@ export default function AttractionTableCard({
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 className="inline-block mt-2 px-4 py-1 text-xs text-white hover:text-white bg-orange-500 rounded-lg shadow hover:bg-orange-600 transition"
+                                onClick={(e) => e.stopPropagation()} // ✅ 링크 클릭 시 카드 클릭 방지
                             >
                                 홈페이지 방문
                             </a>

--- a/src/components/stars/dashboard/AttractionCard.tsx
+++ b/src/components/stars/dashboard/AttractionCard.tsx
@@ -1,3 +1,4 @@
+// ✅ AttractionTableCard.tsx
 import { motion } from "framer-motion";
 import { usePlace } from "../../../context/PlaceContext";
 import { SearchResult } from "../../../api/searchApi";
@@ -36,55 +37,76 @@ export default function AttractionTableCard({
                 관광지 목록
             </h3>
 
-            <ul className="space-y-2 max-h-[300px] overflow-y-auto scrollbar-none rounded-xl">
-                {attractions.map((a, idx) => (
-                    <li
-                        key={idx}
-                        onClick={() => {
-                            const data: SearchResult = {
-                                place_id: idx + 1,
-                                name: a.name,
-                                address: a.address,
-                                phone: a.phone,
-                                lon: a.lon,
-                                lat: a.lat,
-                                type: "attraction",
-                                area_id: selectedAreaId ?? undefined,
-                            };
-                            setHighlightPOI(data);
-                            (
-                                window as unknown as {
-                                    fullpage_api?: {
-                                        moveTo: (n: number) => void;
-                                    };
-                                }
-                            ).fullpage_api?.moveTo(1);
-                        }}
-                        className="p-3 rounded-xl bg-gray-50 hover:bg-orange-50 shadow-sm transition cursor-pointer"
+            {attractions.length === 0 ? (
+                <div className="flex flex-col items-center justify-center text-center text-gray-500 py-8">
+                    {/* SVG 아이콘 */}
+                    <svg
+                        className="w-20 h-20 fill-orange-400"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
                     >
-                        <p className="text-sm font-semibold text-gray-800">
-                            📍 {a.name}
-                        </p>
-                        <p className="text-xs text-gray-500">{a.address}</p>
-                        {a.phone && (
-                            <p className="text-xs text-gray-500">
-                                ☎ {a.phone}
+                        <path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm1 15h-2v-2h2v2Zm0-4h-2V7h2v6Z" />
+                    </svg>
+                    <p className="text-sm font-medium mt-2">
+                        현재 이 관광특구에는
+                        <br />
+                        <span className="font-semibold text-gray-700">
+                            관광지 정보
+                        </span>
+                        가 없습니다.
+                    </p>
+                </div>
+            ) : (
+                <ul className="space-y-2 max-h-[300px] overflow-y-auto scrollbar-none rounded-xl">
+                    {attractions.map((a, idx) => (
+                        <li
+                            key={idx}
+                            onClick={() => {
+                                const data: SearchResult = {
+                                    place_id: idx + 1,
+                                    name: a.name,
+                                    address: a.address,
+                                    phone: a.phone,
+                                    lon: a.lon,
+                                    lat: a.lat,
+                                    type: "attraction",
+                                    area_id: selectedAreaId ?? undefined,
+                                };
+                                setHighlightPOI(data);
+                                (
+                                    window as unknown as {
+                                        fullpage_api?: {
+                                            moveTo: (n: number) => void;
+                                        };
+                                    }
+                                ).fullpage_api?.moveTo(1);
+                            }}
+                            className="p-3 rounded-xl bg-gray-50 hover:bg-orange-50 shadow-sm transition cursor-pointer"
+                        >
+                            <p className="text-sm font-semibold text-gray-800">
+                                📍 {a.name}
                             </p>
-                        )}
-                        {a.homepage_url && (
-                            <a
-                                href={`https://${a.homepage_url}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="inline-block mt-2 px-4 py-1 text-xs text-white hover:text-white bg-orange-500 rounded-lg shadow hover:bg-orange-600 transition"
-                                onClick={(e) => e.stopPropagation()} // ✅ 링크 클릭 시 카드 클릭 방지
-                            >
-                                홈페이지 방문
-                            </a>
-                        )}
-                    </li>
-                ))}
-            </ul>
+                            <p className="text-xs text-gray-500">{a.address}</p>
+                            {a.phone && (
+                                <p className="text-xs text-gray-500">
+                                    ☎ {a.phone}
+                                </p>
+                            )}
+                            {a.homepage_url && (
+                                <a
+                                    href={`https://${a.homepage_url}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-block mt-2 px-4 py-1 text-xs text-white hover:text-white bg-orange-500 rounded-lg shadow hover:bg-orange-600 transition"
+                                    onClick={(e) => e.stopPropagation()}
+                                >
+                                    홈페이지 방문
+                                </a>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            )}
         </motion.div>
     );
 }

--- a/src/components/stars/dashboard/ClickInfoCard.tsx
+++ b/src/components/stars/dashboard/ClickInfoCard.tsx
@@ -1,0 +1,24 @@
+import { motion } from "framer-motion";
+
+interface ClickInfoProps {
+    style: { opacity: number; y: number; scale: number };
+    cardRef: (el: HTMLDivElement | null) => void;
+}
+
+export default function ClickInfoCard({ style, cardRef }: ClickInfoProps) {
+    return (
+        <motion.div
+            className="col-span-12 bg-white text-gray-800 rounded-3xl shadow-lg p-4 text-center font-extrabold text-base"
+            whileHover={{ y: -6 }}
+            animate={
+                style
+                    ? { opacity: style.opacity, y: style.y, scale: style.scale }
+                    : {}
+            }
+            style={style}
+            ref={cardRef}
+        >
+            아래 카드들을 클릭하시면 지도에서 위치를 확인할 수 있어요 🗺️
+        </motion.div>
+    );
+}

--- a/src/components/stars/dashboard/CulturalEventSlider.tsx
+++ b/src/components/stars/dashboard/CulturalEventSlider.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { usePlace } from "../../../context/PlaceContext";
 import { SearchResult } from "../../../api/searchApi";
-import ModalPortal from "../dashboard/ModalPortal"; // 🔸 위치에 맞게 경로 수정
+import ModalPortal from "../dashboard/ModalPortal";
 
 interface CulturalEvent {
     name: string;
@@ -43,7 +43,7 @@ export default function CulturalEventSlider({
     return (
         <>
             <motion.div
-                className="col-span-12 md:col-span-6 lg:col-span-6 bg-white rounded-3xl shadow-lg p-4 my-2 relative"
+                className="col-span-12 md:col-span-6 bg-white rounded-3xl shadow-lg p-4 my-2"
                 whileHover={{ y: -6 }}
                 animate={style}
                 style={style}
@@ -53,112 +53,144 @@ export default function CulturalEventSlider({
                     문화행사
                 </h3>
 
-                <div className="relative overflow-hidden rounded-2xl">
-                    <div
-                        className="flex transition-transform duration-500 ease-in-out"
-                        style={{
-                            transform: `translateX(-${currentIndex * 100}%)`,
-                        }}
-                    >
-                        {events.map((event, idx) => {
-                            const poiForMap: SearchResult = {
-                                place_id: idx + 1,
-                                name: event.name,
-                                address: event.address,
-                                phone: "",
-                                lon: event.lon,
-                                lat: event.lat,
-                                type: "cultural_event",
-                                area_id: selectedAreaId ?? undefined,
-                            };
-
-                            return (
-                                <div
-                                    key={idx}
-                                    className="min-w-full flex flex-col md:flex-row bg-gray-50 hover:bg-lime-50 rounded-2xl p-4 gap-4 min-h-[240px] cursor-pointer"
-                                    onClick={() => {
-                                        setHighlightPOI(poiForMap);
-                                        (
-                                            window as unknown as {
-                                                fullpage_api?: {
-                                                    moveTo: (n: number) => void;
-                                                };
-                                            }
-                                        ).fullpage_api?.moveTo(1);
-                                    }}
-                                >
-                                    {event.event_img && (
-                                        <img
-                                            src={event.event_img}
-                                            alt={event.name}
-                                            className="w-full md:w-36 h-full object-cover rounded-xl cursor-zoom-in"
-                                            onClick={(e) => {
-                                                e.stopPropagation();
-                                                setModalImg(event.event_img!);
-                                            }}
-                                        />
-                                    )}
-                                    <div className="flex flex-col justify-between">
-                                        <h5 className="text-lg font-bold text-gray-900 mb-1">
-                                            {event.name}
-                                        </h5>
-                                        <p className="text-sm text-gray-600">
-                                            {event.category} | {event.target}
-                                        </p>
-                                        <p className="text-xs text-gray-600">
-                                            {event.address}
-                                            <br />
-                                            {event.start_date.slice(
-                                                0,
-                                                10
-                                            )} ~ {event.end_date.slice(0, 10)}
-                                        </p>
-                                        {event.event_fee && (
-                                            <p className="text-xs text-lime-600 mt-1">
-                                                {event.event_fee}
-                                            </p>
-                                        )}
-                                    </div>
-                                </div>
-                            );
-                        })}
+                {events.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center text-center text-gray-500 py-12">
+                        <svg
+                            className="w-20 h-20 fill-lime-400"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 24 24"
+                        >
+                            <path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm1 15h-2v-2h2v2Zm0-4h-2V7h2v6Z" />
+                        </svg>
+                        <p className="text-sm font-medium mt-2">
+                            현재 이 관광특구에는
+                            <br />
+                            <span className="font-semibold text-gray-700">
+                                문화행사 정보
+                            </span>
+                            가 없습니다.
+                        </p>
                     </div>
-                </div>
+                ) : (
+                    <>
+                        <div className="relative overflow-hidden rounded-2xl">
+                            <div
+                                className="flex transition-transform duration-500 ease-in-out"
+                                style={{
+                                    transform: `translateX(-${currentIndex * 100}%)`,
+                                }}
+                            >
+                                {events.map((event, idx) => {
+                                    const poiForMap: SearchResult = {
+                                        place_id: idx + 1,
+                                        name: event.name,
+                                        address: event.address,
+                                        phone: "",
+                                        lon: event.lon,
+                                        lat: event.lat,
+                                        type: "cultural_event",
+                                        area_id: selectedAreaId ?? undefined,
+                                    };
 
-                {/* 인디케이터 */}
-                <div className="flex justify-center items-center gap-1 mb-2">
-                    {events.map((_, idx) => (
-                        <span
-                            key={idx}
-                            className={`w-1.5 h-1.5 mt-2 rounded-full transition-all duration-300 ${
-                                idx === currentIndex
-                                    ? "bg-lime-500 scale-110"
-                                    : "bg-gray-300"
-                            }`}
-                        />
-                    ))}
-                </div>
+                                    return (
+                                        <div
+                                            key={idx}
+                                            className="min-w-full flex flex-col md:flex-row bg-gray-50 hover:bg-lime-50 rounded-2xl p-4 gap-4 min-h-[240px] cursor-pointer"
+                                            onClick={() => {
+                                                setHighlightPOI(poiForMap);
+                                                (
+                                                    window as unknown as {
+                                                        fullpage_api?: {
+                                                            moveTo: (
+                                                                n: number
+                                                            ) => void;
+                                                        };
+                                                    }
+                                                ).fullpage_api?.moveTo(1);
+                                            }}
+                                        >
+                                            {event.event_img && (
+                                                <img
+                                                    src={event.event_img}
+                                                    alt={event.name}
+                                                    className="w-full md:w-36 h-full object-cover rounded-xl cursor-zoom-in"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        setModalImg(
+                                                            event.event_img!
+                                                        );
+                                                    }}
+                                                />
+                                            )}
+                                            <div className="flex flex-col justify-between">
+                                                <h5 className="text-lg font-bold text-gray-900 mb-1">
+                                                    {event.name}
+                                                </h5>
+                                                <p className="text-sm text-gray-600">
+                                                    {event.category} |{" "}
+                                                    {event.target}
+                                                </p>
+                                                <p className="text-xs text-gray-600">
+                                                    {event.address}
+                                                    <br />
+                                                    {event.start_date.slice(
+                                                        0,
+                                                        10
+                                                    )}{" "}
+                                                    ~{" "}
+                                                    {event.end_date.slice(
+                                                        0,
+                                                        10
+                                                    )}
+                                                </p>
+                                                {event.event_fee && (
+                                                    <p className="text-xs text-lime-600 mt-1">
+                                                        {event.event_fee}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </div>
 
-                {/* 버튼 */}
-                <div className="flex justify-between mt-2">
-                    <button
-                        onClick={handlePrev}
-                        disabled={currentIndex === 0}
-                        className="px-3 py-1 bg-gray-100 text-gray-700 rounded-full hover:bg-gray-300 disabled:opacity-50"
-                    >
-                        ← 이전
-                    </button>
-                    <button
-                        onClick={handleNext}
-                        disabled={currentIndex === events.length - 1}
-                        className="px-3 py-1 bg-lime-500 text-white rounded-full hover:bg-lime-600 disabled:opacity-50"
-                    >
-                        다음 →
-                    </button>
-                </div>
+                        {/* 인디케이터 */}
+                        <div className="flex justify-center items-center gap-1 mb-2">
+                            {events.map((_, idx) => (
+                                <span
+                                    key={idx}
+                                    className={`w-1.5 h-1.5 mt-2 rounded-full transition-all duration-300 ${
+                                        idx === currentIndex
+                                            ? "bg-lime-500 scale-110"
+                                            : "bg-gray-300"
+                                    }`}
+                                />
+                            ))}
+                        </div>
+
+                        {/* 버튼 */}
+                        <div className="flex justify-between mt-2">
+                            <button
+                                onClick={handlePrev}
+                                disabled={currentIndex === 0}
+                                className="px-3 py-1 bg-gray-100 text-gray-700 rounded-full hover:bg-gray-300 disabled:opacity-50"
+                            >
+                                ← 이전
+                            </button>
+                            <button
+                                onClick={handleNext}
+                                disabled={currentIndex === events.length - 1}
+                                className="px-3 py-1 bg-lime-500 text-white rounded-full hover:bg-lime-600 disabled:opacity-50"
+                            >
+                                다음 →
+                            </button>
+                        </div>
+                    </>
+                )}
             </motion.div>
 
-            {/* 이미지 모달: Portal로 이동 */}
+            {/* 이미지 모달: Portal + 애니메이션 */}
             <AnimatePresence>
                 {modalImg && (
                     <ModalPortal>

--- a/src/components/stars/dashboard/CulturalEventSlider.tsx
+++ b/src/components/stars/dashboard/CulturalEventSlider.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { usePlace } from "../../../context/PlaceContext";
 import { SearchResult } from "../../../api/searchApi";
+import ModalPortal from "../dashboard/ModalPortal"; // 🔸 위치에 맞게 경로 수정
 
 interface CulturalEvent {
     name: string;
@@ -29,121 +30,159 @@ export default function CulturalEventSlider({
 }: CulturalEventSliderProps) {
     const [currentIndex, setCurrentIndex] = useState(0);
     const { setHighlightPOI, selectedAreaId } = usePlace();
+    const [modalImg, setModalImg] = useState<string | null>(null);
 
     const handleNext = () => {
-        if (currentIndex < events.length - 1) {
-            setCurrentIndex(currentIndex + 1);
-        }
+        if (currentIndex < events.length - 1) setCurrentIndex(currentIndex + 1);
     };
 
     const handlePrev = () => {
-        if (currentIndex > 0) {
-            setCurrentIndex(currentIndex - 1);
-        }
+        if (currentIndex > 0) setCurrentIndex(currentIndex - 1);
     };
 
     return (
-        <motion.div
-            className="col-span-12 md:col-span-6 lg:col-span-6 bg-white rounded-3xl shadow-lg p-4 my-2 relative"
-            whileHover={{ y: -6 }}
-            animate={style}
-            style={style}
-            ref={cardRef}
-        >
-            <h3 className="text-lg font-bold text-lime-500 mb-3">문화행사</h3>
+        <>
+            <motion.div
+                className="col-span-12 md:col-span-6 lg:col-span-6 bg-white rounded-3xl shadow-lg p-4 my-2 relative"
+                whileHover={{ y: -6 }}
+                animate={style}
+                style={style}
+                ref={cardRef}
+            >
+                <h3 className="text-lg font-bold text-lime-500 mb-3">
+                    문화행사
+                </h3>
 
-            <div className="relative overflow-hidden rounded-2xl">
-                <div
-                    className="flex transition-transform duration-500 ease-in-out"
-                    style={{ transform: `translateX(-${currentIndex * 100}%)` }}
-                >
-                    {events.map((event, idx) => (
-                        <div
+                <div className="relative overflow-hidden rounded-2xl">
+                    <div
+                        className="flex transition-transform duration-500 ease-in-out"
+                        style={{
+                            transform: `translateX(-${currentIndex * 100}%)`,
+                        }}
+                    >
+                        {events.map((event, idx) => {
+                            const poiForMap: SearchResult = {
+                                place_id: idx + 1,
+                                name: event.name,
+                                address: event.address,
+                                phone: "",
+                                lon: event.lon,
+                                lat: event.lat,
+                                type: "cultural_event",
+                                area_id: selectedAreaId ?? undefined,
+                            };
+
+                            return (
+                                <div
+                                    key={idx}
+                                    className="min-w-full flex flex-col md:flex-row bg-gray-50 hover:bg-lime-50 rounded-2xl p-4 gap-4 min-h-[240px] cursor-pointer"
+                                    onClick={() => {
+                                        setHighlightPOI(poiForMap);
+                                        (
+                                            window as unknown as {
+                                                fullpage_api?: {
+                                                    moveTo: (n: number) => void;
+                                                };
+                                            }
+                                        ).fullpage_api?.moveTo(1);
+                                    }}
+                                >
+                                    {event.event_img && (
+                                        <img
+                                            src={event.event_img}
+                                            alt={event.name}
+                                            className="w-full md:w-36 h-full object-cover rounded-xl cursor-zoom-in"
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                setModalImg(event.event_img!);
+                                            }}
+                                        />
+                                    )}
+                                    <div className="flex flex-col justify-between">
+                                        <h5 className="text-lg font-bold text-gray-900 mb-1">
+                                            {event.name}
+                                        </h5>
+                                        <p className="text-sm text-gray-600">
+                                            {event.category} | {event.target}
+                                        </p>
+                                        <p className="text-xs text-gray-600">
+                                            {event.address}
+                                            <br />
+                                            {event.start_date.slice(
+                                                0,
+                                                10
+                                            )} ~ {event.end_date.slice(0, 10)}
+                                        </p>
+                                        {event.event_fee && (
+                                            <p className="text-xs text-lime-600 mt-1">
+                                                {event.event_fee}
+                                            </p>
+                                        )}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                {/* 인디케이터 */}
+                <div className="flex justify-center items-center gap-1 mb-2">
+                    {events.map((_, idx) => (
+                        <span
                             key={idx}
-                            onClick={() => {
-                                const poiForMap: SearchResult = {
-                                    place_id: idx + 1,
-                                    name: event.name,
-                                    address: event.address,
-                                    phone: "", // 필요 시 추가
-                                    lon: event.lon,
-                                    lat: event.lat,
-                                    type: "cultural_event",
-                                    area_id: selectedAreaId ?? undefined,
-                                };
-                                setHighlightPOI(poiForMap);
-                                (
-                                    window as unknown as {
-                                        fullpage_api?: {
-                                            moveTo: (n: number) => void;
-                                        };
-                                    }
-                                ).fullpage_api?.moveTo(1);
-                            }}
-                            className="min-w-full flex flex-col md:flex-row bg-gray-50 hover:bg-lime-50 rounded-2xl p-4 gap-4 min-h-[240px] cursor-pointer"
-                        >
-                            {event.event_img && (
-                                <img
-                                    src={event.event_img}
-                                    alt={event.name}
-                                    className="w-full md:w-36 h-full object-cover rounded-xl"
-                                />
-                            )}
-                            <div className="flex flex-col justify-between">
-                                <h5 className="text-lg font-bold text-gray-900 mb-1">
-                                    {event.name}
-                                </h5>
-                                <p className="text-sm text-gray-600">
-                                    {event.category} | {event.target}
-                                </p>
-                                <p className="text-xs text-gray-600">
-                                    {event.address}
-                                    <br />
-                                    {event.start_date.slice(0, 10)} ~{" "}
-                                    {event.end_date.slice(0, 10)}
-                                </p>
-                                {event.event_fee && (
-                                    <p className="text-xs text-lime-600 mt-1">
-                                        {event.event_fee}
-                                    </p>
-                                )}
-                            </div>
-                        </div>
+                            className={`w-1.5 h-1.5 mt-2 rounded-full transition-all duration-300 ${
+                                idx === currentIndex
+                                    ? "bg-lime-500 scale-110"
+                                    : "bg-gray-300"
+                            }`}
+                        />
                     ))}
                 </div>
-            </div>
 
-            {/* 인디케이터 */}
-            <div className="flex justify-center items-center gap-1 mb-2">
-                {events.map((_, idx) => (
-                    <span
-                        key={idx}
-                        className={`w-1.5 h-1.5 mt-2 rounded-full transition-all duration-300 ${
-                            idx === currentIndex
-                                ? "bg-lime-500 scale-110"
-                                : "bg-gray-300"
-                        }`}
-                    />
-                ))}
-            </div>
+                {/* 버튼 */}
+                <div className="flex justify-between mt-2">
+                    <button
+                        onClick={handlePrev}
+                        disabled={currentIndex === 0}
+                        className="px-3 py-1 bg-gray-100 text-gray-700 rounded-full hover:bg-gray-300 disabled:opacity-50"
+                    >
+                        ← 이전
+                    </button>
+                    <button
+                        onClick={handleNext}
+                        disabled={currentIndex === events.length - 1}
+                        className="px-3 py-1 bg-lime-500 text-white rounded-full hover:bg-lime-600 disabled:opacity-50"
+                    >
+                        다음 →
+                    </button>
+                </div>
+            </motion.div>
 
-            {/* 버튼 */}
-            <div className="flex justify-between mt-2">
-                <button
-                    onClick={handlePrev}
-                    disabled={currentIndex === 0}
-                    className="px-3 py-1 bg-gray-100 text-gray-700 rounded-full hover:bg-gray-300 disabled:opacity-50"
-                >
-                    ← 이전
-                </button>
-                <button
-                    onClick={handleNext}
-                    disabled={currentIndex === events.length - 1}
-                    className="px-3 py-1 bg-lime-500 text-white rounded-full hover:bg-lime-600 disabled:opacity-50"
-                >
-                    다음 →
-                </button>
-            </div>
-        </motion.div>
+            {/* 이미지 모달: Portal로 이동 */}
+            <AnimatePresence>
+                {modalImg && (
+                    <ModalPortal>
+                        <motion.div
+                            className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+                            onClick={() => setModalImg(null)}
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                        >
+                            <motion.img
+                                src={modalImg}
+                                alt="이벤트 이미지"
+                                initial={{ opacity: 0, scale: 0.95 }}
+                                animate={{ opacity: 1, scale: 1 }}
+                                exit={{ opacity: 0, scale: 0.95 }}
+                                transition={{ duration: 0.3 }}
+                                className="max-w-[90vw] max-h-[80vh] rounded-2xl shadow-2xl border-4 border-white"
+                                onClick={(e) => e.stopPropagation()}
+                            />
+                        </motion.div>
+                    </ModalPortal>
+                )}
+            </AnimatePresence>
+        </>
     );
 }

--- a/src/components/stars/dashboard/CulturalEventSlider.tsx
+++ b/src/components/stars/dashboard/CulturalEventSlider.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
+import { usePlace } from "../../../context/PlaceContext";
+import { SearchResult } from "../../../api/searchApi";
 
 interface CulturalEvent {
     name: string;
@@ -10,6 +12,8 @@ interface CulturalEvent {
     end_date: string;
     event_fee?: string;
     event_img?: string;
+    lat: number;
+    lon: number;
 }
 
 interface CulturalEventSliderProps {
@@ -24,6 +28,7 @@ export default function CulturalEventSlider({
     cardRef,
 }: CulturalEventSliderProps) {
     const [currentIndex, setCurrentIndex] = useState(0);
+    const { setHighlightPOI, selectedAreaId } = usePlace();
 
     const handleNext = () => {
         if (currentIndex < events.length - 1) {
@@ -55,7 +60,27 @@ export default function CulturalEventSlider({
                     {events.map((event, idx) => (
                         <div
                             key={idx}
-                            className="min-w-full flex flex-col md:flex-row bg-gray-50 hover:bg-lime-50 rounded-2xl p-4 gap-4 min-h-[240px]"
+                            onClick={() => {
+                                const poiForMap: SearchResult = {
+                                    place_id: idx + 1,
+                                    name: event.name,
+                                    address: event.address,
+                                    phone: "", // 필요 시 추가
+                                    lon: event.lon,
+                                    lat: event.lat,
+                                    type: "cultural_event",
+                                    area_id: selectedAreaId ?? undefined,
+                                };
+                                setHighlightPOI(poiForMap);
+                                (
+                                    window as unknown as {
+                                        fullpage_api?: {
+                                            moveTo: (n: number) => void;
+                                        };
+                                    }
+                                ).fullpage_api?.moveTo(1);
+                            }}
+                            className="min-w-full flex flex-col md:flex-row bg-gray-50 hover:bg-lime-50 rounded-2xl p-4 gap-4 min-h-[240px] cursor-pointer"
                         >
                             {event.event_img && (
                                 <img

--- a/src/components/stars/dashboard/CulturalEventSlider.tsx
+++ b/src/components/stars/dashboard/CulturalEventSlider.tsx
@@ -2,8 +2,10 @@ import { useState } from "react";
 import { motion } from "framer-motion";
 
 interface CulturalEvent {
-    title: string;
+    name: string;
     address: string;
+    category: string;
+    target: string;
     start_date: string;
     end_date: string;
     event_fee?: string;
@@ -58,14 +60,17 @@ export default function CulturalEventSlider({
                             {event.event_img && (
                                 <img
                                     src={event.event_img}
-                                    alt={event.title}
+                                    alt={event.name}
                                     className="w-full md:w-36 h-full object-cover rounded-xl"
                                 />
                             )}
                             <div className="flex flex-col justify-between">
-                                <h5 className="text-xl font-bold text-gray-900 mb-1">
-                                    {event.title}
+                                <h5 className="text-lg font-bold text-gray-900 mb-1">
+                                    {event.name}
                                 </h5>
+                                <p className="text-sm text-gray-600">
+                                    {event.category} | {event.target}
+                                </p>
                                 <p className="text-sm text-gray-600">
                                     {event.address}
                                 </p>

--- a/src/components/stars/dashboard/CulturalEventSlider.tsx
+++ b/src/components/stars/dashboard/CulturalEventSlider.tsx
@@ -71,15 +71,14 @@ export default function CulturalEventSlider({
                                 <p className="text-sm text-gray-600">
                                     {event.category} | {event.target}
                                 </p>
-                                <p className="text-sm text-gray-600">
+                                <p className="text-xs text-gray-600">
                                     {event.address}
-                                </p>
-                                <p className="text-sm text-gray-500">
+                                    <br />
                                     {event.start_date.slice(0, 10)} ~{" "}
                                     {event.end_date.slice(0, 10)}
                                 </p>
                                 {event.event_fee && (
-                                    <p className="text-sm text-lime-600 mt-1">
+                                    <p className="text-xs text-lime-600 mt-1">
                                         {event.event_fee}
                                     </p>
                                 )}

--- a/src/components/stars/dashboard/DashboardComponent.tsx
+++ b/src/components/stars/dashboard/DashboardComponent.tsx
@@ -12,9 +12,8 @@ import TrafficInfoCard from "./TrafficInfoCard";
 // import ParkingInfoCard from "./ParkingInfoCard";
 import AccidentAlertCard from "./AccidentAlertCard";
 import CongestionStatusCard from "./CongestionStatusCard";
-import AttractionCard from "./AttractionCard";
 import AttractionTableCard from "./AttractionCard";
-import CulturalEventCard from "./CulturalEventCard";
+// import CulturalEventCard from "./CulturalEventCard";
 import CulturalEventSlider from "./CulturalEventSlider";
 import { scrollToTop } from "../../../utils/scrollToTop";
 
@@ -57,8 +56,10 @@ interface Attraction {
 }
 
 interface CulturalEvent {
-    title: string;
+    name: string;
     address: string;
+    category: string;
+    target: string;
     start_date: string;
     end_date: string;
     event_fee?: string;

--- a/src/components/stars/dashboard/DashboardComponent.tsx
+++ b/src/components/stars/dashboard/DashboardComponent.tsx
@@ -449,13 +449,11 @@ export default function DashboardComponent() {
                 {/*))}*/}
 
                 {/* 관광지 카드 - 리스트형 하나로 묶어서 출력 */}
-                {attractions.length > 0 && (
-                    <AttractionTableCard
-                        attractions={attractions}
-                        style={cardStyles[100]} // 인덱스는 하나만 사용
-                        cardRef={(el) => (cardRefs.current[100] = el)}
-                    />
-                )}
+                <AttractionTableCard
+                    attractions={attractions}
+                    style={cardStyles[100]}
+                    cardRef={(el) => (cardRefs.current[100] = el)}
+                />
 
                 <CulturalEventSlider
                     events={events}

--- a/src/components/stars/dashboard/DashboardComponent.tsx
+++ b/src/components/stars/dashboard/DashboardComponent.tsx
@@ -408,6 +408,19 @@ export default function DashboardComponent() {
                     accidentData={selectedAccidents}
                 />
 
+                {/* 위치 보기 안내 멘트 */}
+                <motion.div
+                    className="col-span-12 bg-white text-gray-800 rounded-3xl shadow-lg p-4 text-center font-extrabold text-base"
+                    whileHover={{ y: -6 }}
+                    animate={cardStyles[99]}
+                    style={cardStyles[99]}
+                    ref={(el) => {
+                        cardRefs.current[99] = el;
+                    }}
+                >
+                    아래 카드들을 클릭하시면 지도에서 위치를 확인할 수 있어요 🗺️
+                </motion.div>
+
                 <POITableCard
                     title="카페"
                     pois={cafePOIs}

--- a/src/components/stars/dashboard/DashboardComponent.tsx
+++ b/src/components/stars/dashboard/DashboardComponent.tsx
@@ -38,6 +38,8 @@ interface POI {
     name: string;
     address: string;
     tel: string;
+    lon: number;
+    lat: number;
     type: "cafe" | "restaurant" | "accommodation";
 }
 
@@ -46,6 +48,8 @@ interface POIRawItem {
     cafe_name?: string;
     address: string;
     phone?: string;
+    lon: number;
+    lat: number;
 }
 
 interface Attraction {
@@ -212,6 +216,8 @@ export default function DashboardComponent() {
                             name: item.name || item.cafe_name || "이름 없음",
                             address: item.address,
                             tel: item.phone || "정보없음",
+                            lon: item.lon,
+                            lat: item.lat,
                             type: poiType,
                         }));
                     });

--- a/src/components/stars/dashboard/DashboardComponent.tsx
+++ b/src/components/stars/dashboard/DashboardComponent.tsx
@@ -12,6 +12,7 @@ import TrafficInfoCard from "./TrafficInfoCard";
 // import ParkingInfoCard from "./ParkingInfoCard";
 import AccidentAlertCard from "./AccidentAlertCard";
 import CongestionStatusCard from "./CongestionStatusCard";
+import ClickInfoCard from "./ClickInfoCard";
 import AttractionTableCard from "./AttractionCard";
 // import CulturalEventCard from "./CulturalEventCard";
 import CulturalEventSlider from "./CulturalEventSlider";
@@ -408,18 +409,10 @@ export default function DashboardComponent() {
                     accidentData={selectedAccidents}
                 />
 
-                {/* 위치 보기 안내 멘트 */}
-                <motion.div
-                    className="col-span-12 bg-white text-gray-800 rounded-3xl shadow-lg p-4 text-center font-extrabold text-base"
-                    whileHover={{ y: -6 }}
-                    animate={cardStyles[99]}
+                <ClickInfoCard
                     style={cardStyles[99]}
-                    ref={(el) => {
-                        cardRefs.current[99] = el;
-                    }}
-                >
-                    아래 카드들을 클릭하시면 지도에서 위치를 확인할 수 있어요 🗺️
-                </motion.div>
+                    cardRef={(el) => (cardRefs.current[99] = el)}
+                />
 
                 <POITableCard
                     title="카페"

--- a/src/components/stars/dashboard/DashboardComponent.tsx
+++ b/src/components/stars/dashboard/DashboardComponent.tsx
@@ -57,6 +57,8 @@ interface Attraction {
     address: string;
     phone?: string;
     homepage_url?: string;
+    lat: number;
+    lon: number;
 }
 
 interface CulturalEvent {
@@ -68,6 +70,8 @@ interface CulturalEvent {
     end_date: string;
     event_fee?: string;
     event_img?: string;
+    lat: number;
+    lon: number;
 }
 
 interface WeatherForecast {

--- a/src/components/stars/dashboard/ModalPortal.tsx
+++ b/src/components/stars/dashboard/ModalPortal.tsx
@@ -1,0 +1,26 @@
+import { createPortal } from "react-dom";
+import { useEffect, useState } from "react";
+
+export default function ModalPortal({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    const [mounted, setMounted] = useState(false);
+    const [container] = useState(() => {
+        const el = document.createElement("div");
+        el.id = "modal-root";
+        el.className = "fixed inset-0 z-[9999]";
+        return el;
+    });
+
+    useEffect(() => {
+        document.body.appendChild(container);
+        setMounted(true);
+        return () => {
+            document.body.removeChild(container);
+        };
+    }, [container]);
+
+    return mounted ? createPortal(children, container) : null;
+}

--- a/src/components/stars/dashboard/POITableCard.tsx
+++ b/src/components/stars/dashboard/POITableCard.tsx
@@ -1,10 +1,15 @@
 // ✅ POITableCard.tsx
 import { motion } from "framer-motion";
+import { usePlace } from "../../../context/PlaceContext";
+import { SearchResult } from "../../../api/searchApi";
 
 interface POI {
     name: string;
     address: string;
     tel: string;
+    lon: number;
+    lat: number;
+    type: "restaurant" | "cafe" | "accommodation";
 }
 
 interface POITableCardProps {
@@ -20,6 +25,8 @@ export default function POITableCard({
     style,
     cardRef,
 }: POITableCardProps) {
+    const { selectedAreaId, setHighlightPOI } = usePlace();
+
     return (
         <motion.div
             className="col-span-12 sm:col-span-6 md:col-span-4 bg-white rounded-3xl shadow-lg p-4 my-2"
@@ -33,6 +40,37 @@ export default function POITableCard({
                 {pois.map((poi, idx) => (
                     <li
                         key={idx}
+                        onClick={() => {
+                            // 좌표 유효성 체크
+                            if (
+                                !poi.lon ||
+                                !poi.lat ||
+                                isNaN(poi.lon) ||
+                                isNaN(poi.lat)
+                            ) {
+                                console.warn("Invalid POI location:", poi);
+                                return;
+                            }
+
+                            const poiForMap: SearchResult = {
+                                place_id: idx + 1, // ID가 없다면 유니크한 값 필요
+                                name: poi.name,
+                                address: poi.address,
+                                phone: poi.tel,
+                                lon: poi.lon,
+                                lat: poi.lat,
+                                type: poi.type,
+                                area_id: selectedAreaId ?? undefined, // 필요 시
+                            };
+                            setHighlightPOI(poiForMap);
+                            (
+                                window as unknown as {
+                                    fullpage_api?: {
+                                        moveTo: (n: number) => void;
+                                    };
+                                }
+                            ).fullpage_api?.moveTo(1);
+                        }}
                         className="bg-gray-50 hover:bg-indigo-50 transition rounded-xl px-4 py-3 shadow-sm"
                     >
                         <p className="text-sm font-semibold text-gray-800 truncate">

--- a/src/components/stars/dashboard/POITableCard.tsx
+++ b/src/components/stars/dashboard/POITableCard.tsx
@@ -36,55 +36,86 @@ export default function POITableCard({
             ref={cardRef}
         >
             <h3 className="text-lg font-bold text-indigo-600 mb-3">{title}</h3>
-            <ul className="space-y-2 max-h-[300px] overflow-y-auto scrollbar-none rounded-xl">
-                {pois.map((poi, idx) => (
-                    <li
-                        key={idx}
-                        onClick={() => {
-                            // 좌표 유효성 체크
-                            if (
-                                !poi.lon ||
-                                !poi.lat ||
-                                isNaN(poi.lon) ||
-                                isNaN(poi.lat)
-                            ) {
-                                console.warn("Invalid POI location:", poi);
-                                return;
-                            }
-
-                            const poiForMap: SearchResult = {
-                                place_id: idx + 1, // ID가 없다면 유니크한 값 필요
-                                name: poi.name,
-                                address: poi.address,
-                                phone: poi.tel,
-                                lon: poi.lon,
-                                lat: poi.lat,
-                                type: poi.type,
-                                area_id: selectedAreaId ?? undefined, // 필요 시
-                            };
-                            setHighlightPOI(poiForMap);
-                            (
-                                window as unknown as {
-                                    fullpage_api?: {
-                                        moveTo: (n: number) => void;
-                                    };
-                                }
-                            ).fullpage_api?.moveTo(1);
-                        }}
-                        className="bg-gray-50 hover:bg-indigo-50 transition rounded-xl px-4 py-3 shadow-sm"
+            {pois.length === 0 ? (
+                <div className="flex flex-col items-center justify-center text-center text-gray-500 py-8">
+                    {/* SVG 아이콘 */}
+                    <svg
+                        fill="#7c86ff"
+                        width="80px"
+                        height="80px"
+                        viewBox="-1 0 19 19"
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="cf-icon-svg"
                     >
-                        <p className="text-sm font-semibold text-gray-800 truncate">
-                            📍 {poi.name}
-                        </p>
-                        <p className="text-xs text-gray-500 truncate mt-0.5">
-                            {poi.address}
-                        </p>
-                        <p className="text-xs text-indigo-600 font-medium mt-1">
-                            ☎ {poi.tel}
-                        </p>
-                    </li>
-                ))}
-            </ul>
+                        <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+                        <g
+                            id="SVGRepo_tracerCarrier"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        ></g>
+                        <g id="SVGRepo_iconCarrier">
+                            <path d="M16.417 9.583A7.917 7.917 0 1 1 8.5 1.666a7.917 7.917 0 0 1 7.917 7.917zm-5.267 6.274a6.766 6.766 0 0 0 1.756-1.084L3.31 5.177a6.81 6.81 0 0 0 7.84 10.68zm3.624-3.624a6.808 6.808 0 0 0-10.68-7.84l9.596 9.596a6.77 6.77 0 0 0 1.084-1.756z"></path>
+                        </g>
+                    </svg>
+                    <p className="text-sm font-medium">
+                        현재 이 관광특구에는
+                        <br />
+                        <span className="font-semibold text-gray-700">
+                            {title}
+                        </span>{" "}
+                        정보가 없습니다.
+                    </p>
+                </div>
+            ) : (
+                <ul className="space-y-2 max-h-[300px] overflow-y-auto scrollbar-none rounded-xl">
+                    {pois.map((poi, idx) => (
+                        <li
+                            key={idx}
+                            onClick={() => {
+                                if (
+                                    !poi.lon ||
+                                    !poi.lat ||
+                                    isNaN(poi.lon) ||
+                                    isNaN(poi.lat)
+                                ) {
+                                    console.warn("Invalid POI location:", poi);
+                                    return;
+                                }
+
+                                const poiForMap: SearchResult = {
+                                    place_id: idx + 1,
+                                    name: poi.name,
+                                    address: poi.address,
+                                    phone: poi.tel,
+                                    lon: poi.lon,
+                                    lat: poi.lat,
+                                    type: poi.type,
+                                    area_id: selectedAreaId ?? undefined,
+                                };
+                                setHighlightPOI(poiForMap);
+                                (
+                                    window as unknown as {
+                                        fullpage_api?: {
+                                            moveTo: (n: number) => void;
+                                        };
+                                    }
+                                ).fullpage_api?.moveTo(1);
+                            }}
+                            className="bg-gray-50 hover:bg-indigo-50 transition rounded-xl px-4 py-3 shadow-sm cursor-pointer"
+                        >
+                            <p className="text-sm font-semibold text-gray-800 truncate">
+                                📍 {poi.name}
+                            </p>
+                            <p className="text-xs text-gray-500 truncate mt-0.5">
+                                {poi.address}
+                            </p>
+                            <p className="text-xs text-indigo-600 font-medium mt-1">
+                                ☎ {poi.tel}
+                            </p>
+                        </li>
+                    ))}
+                </ul>
+            )}
         </motion.div>
     );
 }

--- a/src/components/stars/dashboard/POITableCard.tsx
+++ b/src/components/stars/dashboard/POITableCard.tsx
@@ -40,22 +40,11 @@ export default function POITableCard({
                 <div className="flex flex-col items-center justify-center text-center text-gray-500 py-8">
                     {/* SVG 아이콘 */}
                     <svg
-                        fill="#7c86ff"
-                        width="80px"
-                        height="80px"
-                        viewBox="-1 0 19 19"
+                        className="w-20 h-20 fill-indigo-400"
+                        viewBox="0 0 24 24"
                         xmlns="http://www.w3.org/2000/svg"
-                        className="cf-icon-svg"
                     >
-                        <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-                        <g
-                            id="SVGRepo_tracerCarrier"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                        ></g>
-                        <g id="SVGRepo_iconCarrier">
-                            <path d="M16.417 9.583A7.917 7.917 0 1 1 8.5 1.666a7.917 7.917 0 0 1 7.917 7.917zm-5.267 6.274a6.766 6.766 0 0 0 1.756-1.084L3.31 5.177a6.81 6.81 0 0 0 7.84 10.68zm3.624-3.624a6.808 6.808 0 0 0-10.68-7.84l9.596 9.596a6.77 6.77 0 0 0 1.084-1.756z"></path>
-                        </g>
+                        <path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm1 15h-2v-2h2v2Zm0-4h-2V7h2v6Z" />
                     </svg>
                     <p className="text-sm font-medium">
                         현재 이 관광특구에는

--- a/src/context/PlaceContext.tsx
+++ b/src/context/PlaceContext.tsx
@@ -1,6 +1,7 @@
 // src/context/PlaceContext.tsx
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { subscribeCongestionUpdate, subscribeExternal } from "../api/starsApi";
+import { SearchResult } from "../api/searchApi";
 import {
     MapData,
     ParkData,
@@ -44,6 +45,9 @@ interface PlaceContextType {
     mapData: MapData[] | null;
 
     accidentData: AccidentData[];
+
+    highlightPOI: SearchResult | null;
+    setHighlightPOI: (poi: SearchResult | null) => void;
 }
 
 const PlaceContext = createContext<PlaceContextType | undefined>(undefined);
@@ -61,6 +65,7 @@ export function PlaceProvider({ children }: { children: React.ReactNode }) {
     const [congestionInfo, setCongestionInfo] = useState<CongestionData | null>(
         null
     );
+    const [highlightPOI, setHighlightPOI] = useState<SearchResult | null>(null);
 
     // ✅ SSE 연결
     useEffect(() => {
@@ -152,6 +157,8 @@ export function PlaceProvider({ children }: { children: React.ReactNode }) {
                 congestionInfo,
                 mapData,
                 accidentData,
+                highlightPOI,
+                setHighlightPOI,
             }}
         >
             {children}


### PR DESCRIPTION
1.	feat: POI 리스트 카드에서 지도 마커와 연동 기능 구현
	•	POITableCard → MapSection 연동 (setHighlightPOI, SearchResult)
	•	클릭 시 마커 + 팝업 + 지도 이동 처리
	2.	feat: 관광지 카드에서 지도 연동 기능 구현
	•	AttractionTableCard 구현 및 연동
	•	관광지 클릭 → 지도 이동 (place_id, type: "attraction")
	3.	feat: 문화행사 카드에서 지도 연동 및 슬라이더 구현
	•	CulturalEventSlider 슬라이드 기반 구조 구현
	•	이벤트 클릭 시 지도 이동
	4.	feat: 문화행사 카드 클릭 시 이미지 모달 기능 추가
	•	이미지 클릭 시 확대 모달 표시
	•	ModalPortal + AnimatePresence 기반으로 구현
	5.	feat: Dashboard에서 POI 섹션 진입 안내 멘트 컴포넌트 분리 및 삽입
	•	<ClickInfo /> 컴포넌트로 추출
	•	위치: Traffic → POI 카드 사이에 안내 문구 추가
	6.	style: 사고 알림 카드 스크롤 적용 및 최대 높이 설정
	•	AccidentAlertCard에 max-h-[300px], overflow-y-auto 적용
	•	사고 다건 출력 대응
	7.	feat: POI 카드에 정보가 없을 경우 안내 메시지 및 아이콘 추가
	•	pois.length === 0 처리
	•	아이콘(SVG) + 메시지 표시
	8.	feat: 관광지 카드에 정보 없음 처리 추가
	•	attractions.length === 0 처리
	•	orange 아이콘 + 텍스트 추가
	9.	feat: 문화행사 카드에 정보 없을 경우 안내 메시지 추가
	•	events.length === 0 처리
	•	주황색 계열 SVG + 텍스트 포함