### PR TITLE
feat: 서울 중심부만 보이도록 지도 이동 제한 및 최소 줌 조정

### DIFF
--- a/src/hooks/useMapboxInit.ts
+++ b/src/hooks/useMapboxInit.ts
@@ -26,7 +26,11 @@ export function useMapboxInit({
             style: "mapbox://styles/minseoks/cm99i4icd00fe01r9gia5c055",
             center: [126.9779692, 37.566535] as LngLatLike,
             zoom: 10.8,
-            minZoom: 10,
+            minZoom: 10.8,
+            maxBounds: [
+                [126.734086, 37.413294], // Southwest (SW) corner - 대략 서울 남서쪽
+                [127.269311, 37.715133], // Northeast (NE) corner - 대략 서울 북동쪽
+            ],
         });
         map.addControl(
             new NavigationControl({ visualizePitch: true }),


### PR DESCRIPTION
- minZoom 값을 10 → 10.8로 상향 조정하여 과도한 축소 방지
- maxBounds 설정을 통해 지도의 이동 범위를 서울 시내로 제한
  - 남서쪽: [126.734086, 37.413294]
  - 북동쪽: [127.269311, 37.715133]
- 사용자가 서울 외 지역으로 벗어나는 것을 방지하여 UX 향상